### PR TITLE
Fix GitHub links in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/apexskier/homebridge-airmega.git"
+    "url": "git+https://github.com/apexskier/homebridge-coway.git"
   },
   "bugs": {
-    "url": "https://github.com/apexskier/homebridge-airmega/issues"
+    "url": "https://github.com/apexskier/homebridge-coway/issues"
   },
   "funding": [
     {


### PR DESCRIPTION
Thanks for writing this plugin! 🙏  I found it while browsing around. Initially I found the package on [npm](https://www.npmjs.com/package/@apexskier/homebridge-airmega) and when trying to view the source I noticed the links to the repo are broken. Figured I'd send a patch to fix (assuming it'd be best to keep the package name the same).